### PR TITLE
Ajuste na margem de alguns elementos

### DIFF
--- a/src/components/vantagens.collection/Advantage.jsx
+++ b/src/components/vantagens.collection/Advantage.jsx
@@ -1,6 +1,6 @@
 const Advantage = ({ title, txt, icon }) => {
   return (
-    <div className="w-96 bg-dark-color-second min-h-[188px] p-8 rounded-lg flex flex-col gap-4 text-[#F2F0FF] font-mulish small-screen:min-h-[290px] small-screen:gap-2">
+    <div className="w-96 bg-dark-color-second min-h-[188px] p-8 m-3 rounded-lg flex flex-col gap-4 text-[#F2F0FF] font-mulish small-screen:min-h-[290px] small-screen:gap-2 small-screen:m-0">
       <h3 className="font-bold text-[16px] small-screen:text-[19px]
       flex gap-[10px] items-center"><span className="text-[22px] text-primary-button">{icon}</span>{title}</h3>
       <p className="text-[12px] small-screen:text-[15px]">{txt}</p>

--- a/src/components/vantagens.collection/Advantages.jsx
+++ b/src/components/vantagens.collection/Advantages.jsx
@@ -10,7 +10,7 @@ const Advantages = () => {
   return (
     <div className="bg-dark-color">
       <div className="m-auto flex flex-wrap items-center justify-center p-2 gap-4 mega-screen:max-w-[1212px]">
-        <div className="w-96 text-[#F2F0FF] pt-8 pb-8 pr-8 space-y-4 min-h-[161px] small-screen:min-h-[290px]">
+        <div className="w-96 text-[#F2F0FF] pt-8 pb-8 pr-8 m-3 space-y-4 min-h-[161px] small-screen:min-h-[290px] small-screen:m-0">
           <h3 className="text-[22px] font-black font-inconsolata leading-6 small-screen:text-[32px] small-screen:leading-8">
             Vantagens do <br /> Projeto
           </h3>


### PR DESCRIPTION
**Ajuste** na **margem** exterior dos `elementos relacionados as Vantagens`.

Foram ajustadas para `12px` as margem em **telas menores** e, para **telas maiores**, um ajuste no `gap `do **elemento pai** dos blocos de Vantagens.

Resultado visual antes da alteração de margem: 

![sem-margem](https://github.com/Projeto-FrontEnd-Fusion/portifolio-colaborativo-code-wizard/assets/143457523/5901bc13-120c-4774-b309-e79aefeda2ff)

Resultado visual após a alteração de margem:

![com-margem](https://github.com/Projeto-FrontEnd-Fusion/portifolio-colaborativo-code-wizard/assets/143457523/cc473f37-3bbc-4c60-8171-ed7687e55b52)
